### PR TITLE
fix(core): Include ee nodes when validating PR titles

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -9,8 +9,10 @@ const LANGCHAIN_NODES_DIR = path.resolve("packages", "@n8n", "nodes-langchain", 
 async function getDisplayNames() {
   const [nodeFilepaths, versionDescriptionFilepaths, lcNodeFilepaths, lcVersionDescriptionFilepaths] = await Promise.all([
     glob(path.resolve(NODES_DIR, "**", "*.node.ts")),
+    glob(path.resolve(NODES_DIR, "**", "*.node.ee.ts")),
     glob(path.resolve(NODES_DIR, "**", "versionDescription.ts")),
     glob(path.resolve(LANGCHAIN_NODES_DIR, "**", "*.node.ts")),
+    glob(path.resolve(LANGCHAIN_NODES_DIR, "**", "*.node.ee.ts")),
     glob(path.resolve(LANGCHAIN_NODES_DIR, "**", "versionDescription.ts")),
   ]);
 


### PR DESCRIPTION
This PR adjusts the files we look at for node display names when validating a PR title by adding also `.ee.ts` extensions.